### PR TITLE
Fix - update 'Release' stage dependants

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -81,7 +81,9 @@ stages:
 
   - stage: Release
     displayName: 'Release to NuGet.org'
-    dependsOn: IntegrationTests
+    dependsOn:
+      - UnitTests
+      - IntegrationTests
     condition: succeeded()
     jobs:
       - job: PushToNuGet


### PR DESCRIPTION
Use both the unit and integration tests as depandents of 'Release' stage.